### PR TITLE
feat: add Ollama-based alt text service (zero ML dependencies)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+
+# Python virtual environments
+vlm-env/
+venv/
+.venv/
+__pycache__/
+*.py[cod]

--- a/ollama_service/README.md
+++ b/ollama_service/README.md
@@ -34,7 +34,7 @@ curl -fsSL https://ollama.com/install.sh | sh
 ollama pull qwen3-vl:4b
 ```
 
-### 3. Start Ollama (if not running as service)
+### 3. Start Ollama (if not running as a service)
 
 ```bash
 ollama serve

--- a/ollama_service/README.md
+++ b/ollama_service/README.md
@@ -2,6 +2,22 @@
 
 Lightweight alt text generation service using **Ollama** - no Python ML dependencies required.
 
+## Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/fairdataihub/alt-text-generator.git
+cd alt-text-generator
+
+# Install Ollama and pull the vision model
+curl -fsSL https://ollama.com/install.sh | sh
+ollama pull qwen3-vl:4b
+
+# Install Python dependencies and start the server
+pip install flask requests
+python ollama_service/server.py
+```
+
 ## Why Ollama?
 
 | Aspect | Transformers Version | Ollama Version |
@@ -81,7 +97,7 @@ curl http://localhost:5000/health
 Generate alt text for an image.
 
 ```bash
-curl "http://localhost:5000/generate?imageUrl=https://dub.sh/confpic"
+curl "http://localhost:5000/generate?imageUrl=https://fairdataihub.org/images/blog/ismb-2025/dorian-team.jpeg"
 ```
 
 #### `POST /generate`

--- a/ollama_service/README.md
+++ b/ollama_service/README.md
@@ -1,0 +1,135 @@
+# Alt Text Generator (Ollama Edition)
+
+Lightweight alt text generation service using **Ollama** - no Python ML dependencies required.
+
+## Why Ollama?
+
+| Aspect | Transformers Version | Ollama Version |
+|--------|---------------------|----------------|
+| Python deps | PyTorch, Transformers, etc (~5-10GB) | Flask, Requests (~1MB) |
+| Model management | Manual HF cache | `ollama pull/list/rm` |
+| Setup complexity | Virtual env, CUDA, etc | Single binary + one command |
+| Portability | Python 3.10+, CUDA | Any system Ollama supports |
+
+## Model
+
+| Property | Value |
+|----------|-------|
+| **Model** | qwen3-vl:4b |
+| **Parameters** | 4B |
+| **Size** | 3.3 GB |
+| **Runtime** | Ollama |
+
+## Prerequisites
+
+### 1. Install Ollama
+
+```bash
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+### 2. Pull the model
+
+```bash
+ollama pull qwen3-vl:4b
+```
+
+### 3. Start Ollama (if not running as service)
+
+```bash
+ollama serve
+```
+
+## Setup
+
+### Install Python dependencies (minimal!)
+
+```bash
+pip install flask requests
+# That's it! No PyTorch, no Transformers, no CUDA toolkit
+```
+
+Or use the requirements file:
+
+```bash
+pip install -r ollama_service/requirements.txt
+```
+
+## Usage
+
+### Start the server
+
+```bash
+python ollama_service/server.py
+```
+
+Server runs on `http://localhost:5000` by default.
+
+### API Endpoints
+
+#### `GET /`
+Landing page with API info.
+
+#### `GET /health`
+Health check - verifies Ollama is running and model is available.
+
+```bash
+curl http://localhost:5000/health
+```
+
+#### `GET /generate?imageUrl=<url>`
+Generate alt text for an image.
+
+```bash
+curl "http://localhost:5000/generate?imageUrl=https://dub.sh/confpic"
+```
+
+#### `POST /generate`
+Generate alt text with custom prompt.
+
+```bash
+curl -X POST http://localhost:5000/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "imageUrl": "https://example.com/image.jpg",
+    "prompt": "Describe this image for a visually impaired user."
+  }'
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | 5000 | Server port |
+| `OLLAMA_HOST` | http://localhost:11434 | Ollama API URL |
+| `OLLAMA_MODEL` | qwen3-vl:4b | Model to use |
+
+## Comparison with Transformers Version
+
+| Metric | Transformers (R-4B) | Ollama (qwen3-vl:4b) |
+|--------|--------------------|-----------------------|
+| MMStar Score | 72.6 | TBD (likely lower) |
+| Parameters | 4.82B | 4B |
+| Python deps | ~5-10GB | ~1MB |
+| Setup time | 10-15 min | 2 min |
+| Model download | ~10GB (HF) | 3.3GB (Ollama) |
+
+## Troubleshooting
+
+### "Cannot connect to Ollama"
+Make sure Ollama is running:
+```bash
+ollama serve
+```
+
+### Model not found
+Pull the model:
+```bash
+ollama pull qwen3-vl:4b
+```
+
+### Check available models
+```bash
+ollama list
+```
+

--- a/ollama_service/requirements.txt
+++ b/ollama_service/requirements.txt
@@ -1,0 +1,14 @@
+# Ollama Alt Text Generator - Minimal Dependencies
+# =================================================
+#
+# This is the lightweight version - no PyTorch, no Transformers!
+# Model inference is handled by Ollama.
+#
+# Prerequisites:
+#   1. Install Ollama: curl -fsSL https://ollama.com/install.sh | sh
+#   2. Pull model: ollama pull qwen3-vl:4b
+#   3. Start Ollama: ollama serve
+
+flask>=3.0.0
+requests>=2.31.0
+

--- a/ollama_service/server.py
+++ b/ollama_service/server.py
@@ -37,15 +37,112 @@ OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 MODEL_NAME = os.environ.get("OLLAMA_MODEL", "qwen3-vl:4b")
 DEFAULT_PROMPT = "Describe this image in one concise sentence for alt text."
 
+# Image fetch constraints
+MAX_IMAGE_BYTES = 10 * 1024 * 1024  # 10 MiB
+ALLOWED_IMAGE_MIME_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+    "image/jpg",
+}
+MAX_REDIRECTS = 5
+
+# Blocked IP ranges for SSRF protection
+BLOCKED_IP_PREFIXES = (
+    "127.", "10.", "192.168.", "172.16.", "172.17.", "172.18.", "172.19.",
+    "172.20.", "172.21.", "172.22.", "172.23.", "172.24.", "172.25.",
+    "172.26.", "172.27.", "172.28.", "172.29.", "172.30.", "172.31.",
+    "0.", "169.254.", "::1", "fc00:", "fe80:", "localhost"
+)
+
 # Initialize Flask app
 app = Flask(__name__)
 
 
+def validate_url(url: str) -> None:
+    """
+    Validate URL to prevent SSRF attacks.
+    Raises ValueError if URL is invalid or points to blocked resources.
+    """
+    from urllib.parse import urlparse
+    import socket
+    
+    parsed = urlparse(url)
+    
+    # Enforce http/https only
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError("Only HTTP and HTTPS URLs are allowed")
+    
+    if not parsed.netloc:
+        raise ValueError("Invalid URL: missing host")
+    
+    # Extract hostname (handle port if present)
+    hostname = parsed.hostname or parsed.netloc.split(":")[0]
+    
+    # Block localhost and private IPs by hostname
+    hostname_lower = hostname.lower()
+    if any(hostname_lower.startswith(prefix) or hostname_lower == prefix.rstrip(".")
+           for prefix in BLOCKED_IP_PREFIXES):
+        raise ValueError("Access to internal network resources is not allowed")
+    
+    # Resolve hostname and check IP
+    try:
+        ip = socket.gethostbyname(hostname)
+        if any(ip.startswith(prefix) for prefix in BLOCKED_IP_PREFIXES):
+            raise ValueError("Access to internal network resources is not allowed")
+    except socket.gaierror:
+        raise ValueError(f"Unable to resolve hostname: {hostname}")
+
+
 def fetch_image_as_base64(image_url: str) -> str:
-    """Download an image from URL and return as base64 string."""
-    response = requests.get(image_url, timeout=30)
-    response.raise_for_status()
-    return base64.b64encode(response.content).decode('utf-8')
+    """
+    Download an image from URL and return as base64 string.
+    Includes validation for content type, size limits, and redirect restrictions.
+    """
+    # Validate URL before fetching
+    validate_url(image_url)
+    
+    with requests.Session() as session:
+        session.max_redirects = MAX_REDIRECTS
+        
+        response = session.get(
+            image_url,
+            timeout=30,
+            stream=True,
+        )
+        response.raise_for_status()
+        
+        # Validate content type
+        content_type = response.headers.get("Content-Type", "")
+        mime_type = content_type.split(";", 1)[0].strip().lower()
+        if mime_type not in ALLOWED_IMAGE_MIME_TYPES:
+            raise ValueError(f"Unsupported content type: {mime_type}. Expected an image.")
+        
+        # Check declared content length if available
+        content_length = response.headers.get("Content-Length")
+        if content_length is not None:
+            try:
+                length = int(content_length)
+                if length > MAX_IMAGE_BYTES:
+                    raise ValueError(
+                        f"Image too large ({length // (1024*1024)}MB). "
+                        f"Maximum allowed: {MAX_IMAGE_BYTES // (1024*1024)}MB"
+                    )
+            except ValueError:
+                pass  # Invalid Content-Length header, continue with streaming check
+        
+        # Stream content and enforce max size
+        chunks = bytearray()
+        for chunk in response.iter_content(chunk_size=8192):
+            if chunk:
+                chunks.extend(chunk)
+                if len(chunks) > MAX_IMAGE_BYTES:
+                    raise ValueError(
+                        f"Image exceeded maximum size of {MAX_IMAGE_BYTES // (1024*1024)}MB"
+                    )
+        
+        return base64.b64encode(bytes(chunks)).decode("utf-8")
 
 
 def generate_caption(image_base64: str, prompt: str = DEFAULT_PROMPT) -> str:
@@ -205,7 +302,8 @@ def health():
         response = requests.get(f"{OLLAMA_HOST}/api/tags", timeout=5)
         ollama_ok = response.status_code == 200
         models = [m["name"] for m in response.json().get("models", [])]
-        model_available = any(MODEL_NAME in m for m in models)
+        # Use exact matching to avoid false positives from similar model names
+        model_available = any(m == MODEL_NAME for m in models)
     except Exception as e:
         ollama_ok = False
         model_available = False
@@ -266,9 +364,18 @@ def generate():
         return jsonify({
             "error": "Cannot connect to Ollama. Is it running? Start with: ollama serve"
         }), 503
+    except ValueError as e:
+        # ValueError is raised by our validation functions with safe messages
+        logger.warning(f"Validation error: {e}")
+        return jsonify({"error": str(e)}), 400
+    except requests.exceptions.RequestException as e:
+        # Network/HTTP errors when fetching image
+        logger.error(f"Error fetching image: {e}", exc_info=True)
+        return jsonify({"error": "Failed to fetch image from the provided URL"}), 400
     except Exception as e:
+        # Log full exception internally but return generic message to client
         logger.error(f"Error generating caption: {e}", exc_info=True)
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An internal error occurred while processing the request"}), 500
 
 
 if __name__ == "__main__":

--- a/ollama_service/server.py
+++ b/ollama_service/server.py
@@ -1,0 +1,281 @@
+"""
+Ollama-based Alt Text Generator API
+====================================
+
+Lightweight Flask API server using Ollama for VLM inference.
+No Python ML dependencies required - just requests and flask.
+
+Model: qwen3-vl:4b (via Ollama)
+
+Prerequisites:
+    1. Install Ollama: curl -fsSL https://ollama.com/install.sh | sh
+    2. Pull the model: ollama pull qwen3-vl:4b
+    3. Start Ollama: ollama serve
+
+Usage:
+    python ollama_service/server.py
+    curl "http://localhost:5000/generate?imageUrl=https://example.com/image.jpg"
+"""
+
+import os
+import base64
+import logging
+from io import BytesIO
+
+import requests
+from flask import Flask, request, jsonify, render_template_string
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+# Configuration
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+MODEL_NAME = os.environ.get("OLLAMA_MODEL", "qwen3-vl:4b")
+DEFAULT_PROMPT = "Describe this image in one concise sentence for alt text."
+
+# Initialize Flask app
+app = Flask(__name__)
+
+
+def fetch_image_as_base64(image_url: str) -> str:
+    """Download an image from URL and return as base64 string."""
+    response = requests.get(image_url, timeout=30)
+    response.raise_for_status()
+    return base64.b64encode(response.content).decode('utf-8')
+
+
+def generate_caption(image_base64: str, prompt: str = DEFAULT_PROMPT) -> str:
+    """Generate a caption using Ollama's API."""
+    response = requests.post(
+        f"{OLLAMA_HOST}/api/generate",
+        json={
+            "model": MODEL_NAME,
+            "prompt": prompt,
+            "images": [image_base64],
+            "stream": False,
+        },
+        timeout=120,
+    )
+    response.raise_for_status()
+    result = response.json()
+    
+    if "error" in result:
+        raise RuntimeError(result["error"])
+    
+    return result.get("response", "").strip()
+
+
+LANDING_PAGE = """
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Alt Text Generator (Ollama)</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, #0f0f23 0%, #1a1a3e 100%);
+            color: #e0e0e0;
+            min-height: 100vh;
+            padding: 2rem;
+        }
+        .container { max-width: 800px; margin: 0 auto; }
+        h1 { 
+            font-size: 2.5rem; 
+            margin-bottom: 0.5rem;
+            background: linear-gradient(90deg, #22c55e, #3b82f6);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+        .subtitle { color: #888; margin-bottom: 2rem; }
+        .badge {
+            display: inline-block;
+            background: rgba(34, 197, 94, 0.2);
+            color: #22c55e;
+            padding: 0.25rem 0.75rem;
+            border-radius: 999px;
+            font-size: 0.8rem;
+            margin-bottom: 1rem;
+        }
+        .model-info {
+            background: rgba(255,255,255,0.05);
+            border-radius: 12px;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+            border: 1px solid rgba(255,255,255,0.1);
+        }
+        .model-info h2 { font-size: 1rem; color: #888; margin-bottom: 1rem; }
+        .stats { display: flex; gap: 2rem; flex-wrap: wrap; }
+        .stat-value { font-size: 1.5rem; font-weight: bold; color: #22c55e; }
+        .stat-label { font-size: 0.85rem; color: #888; }
+        .endpoint {
+            background: rgba(0,0,0,0.3);
+            border-radius: 8px;
+            padding: 1rem 1.5rem;
+            margin-bottom: 1rem;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 0.9rem;
+        }
+        .endpoint code { color: #22c55e; }
+        .try-it {
+            margin-top: 2rem;
+            padding: 1rem;
+            background: rgba(59, 130, 246, 0.2);
+            border-radius: 8px;
+            border: 1px solid rgba(59, 130, 246, 0.3);
+        }
+        .try-it a { color: #3b82f6; word-break: break-all; }
+        .zero-deps {
+            margin-top: 2rem;
+            padding: 1rem;
+            background: rgba(34, 197, 94, 0.1);
+            border-radius: 8px;
+            border: 1px solid rgba(34, 197, 94, 0.2);
+            font-size: 0.9rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="badge">Powered by Ollama</div>
+        <h1>Alt Text Generator</h1>
+        <p class="subtitle">Generate image descriptions using AI - zero Python ML dependencies</p>
+        
+        <div class="model-info">
+            <h2>MODEL</h2>
+            <div class="stats">
+                <div class="stat">
+                    <div class="stat-value">qwen3-vl</div>
+                    <div class="stat-label">4B parameters</div>
+                </div>
+                <div class="stat">
+                    <div class="stat-value">3.3 GB</div>
+                    <div class="stat-label">Model size</div>
+                </div>
+                <div class="stat">
+                    <div class="stat-value">Ollama</div>
+                    <div class="stat-label">Runtime</div>
+                </div>
+            </div>
+        </div>
+        
+        <h2 style="margin-bottom: 1rem; font-size: 1rem; color: #888;">API USAGE</h2>
+        
+        <div class="endpoint">
+            <code>GET /generate?imageUrl=&lt;url&gt;</code>
+        </div>
+        
+        <div class="endpoint">
+            <code>POST /generate</code> with JSON body: <code>{"imageUrl": "..."}</code>
+        </div>
+        
+        <div class="try-it">
+            <strong>Try it:</strong><br>
+            <a href="/generate?imageUrl=https://dub.sh/confpic">/generate?imageUrl=https://dub.sh/confpic</a>
+        </div>
+        
+        <div class="zero-deps">
+            <strong>Zero ML Dependencies:</strong> This service uses Ollama for inference. 
+            No PyTorch, TensorFlow, or heavy Python ML libraries required.
+            Just <code>pip install flask requests</code>.
+        </div>
+    </div>
+</body>
+</html>
+"""
+
+
+@app.route("/", methods=["GET"])
+def index():
+    """Landing page."""
+    return render_template_string(LANDING_PAGE)
+
+
+@app.route("/health", methods=["GET"])
+def health():
+    """Health check endpoint."""
+    # Check if Ollama is reachable
+    try:
+        response = requests.get(f"{OLLAMA_HOST}/api/tags", timeout=5)
+        ollama_ok = response.status_code == 200
+        models = [m["name"] for m in response.json().get("models", [])]
+        model_available = any(MODEL_NAME in m for m in models)
+    except Exception as e:
+        ollama_ok = False
+        model_available = False
+        models = []
+    
+    return jsonify({
+        "status": "healthy" if ollama_ok and model_available else "degraded",
+        "ollama_reachable": ollama_ok,
+        "model": MODEL_NAME,
+        "model_available": model_available,
+        "available_models": models,
+    })
+
+
+@app.route("/generate", methods=["GET", "POST"])
+def generate():
+    """
+    Generate alt text for an image.
+    
+    Query params (GET) or JSON body (POST):
+        imageUrl: URL of the image to caption
+        prompt: (optional) Custom prompt for the model
+    
+    Returns:
+        JSON with "alt_text" field or "error" on failure
+    """
+    try:
+        # Get parameters
+        if request.method == "POST":
+            data = request.get_json() or {}
+            image_url = data.get("imageUrl") or data.get("image_url")
+            prompt = data.get("prompt", DEFAULT_PROMPT)
+        else:
+            image_url = request.args.get("imageUrl") or request.args.get("image_url")
+            prompt = request.args.get("prompt", DEFAULT_PROMPT)
+        
+        if not image_url:
+            return jsonify({"error": "imageUrl parameter is required"}), 400
+        
+        logger.info(f"Generating caption for: {image_url}")
+        
+        # Fetch image and convert to base64
+        image_b64 = fetch_image_as_base64(image_url)
+        
+        # Generate caption via Ollama
+        alt_text = generate_caption(image_b64, prompt)
+        
+        logger.info(f"Generated: {alt_text[:100]}...")
+        
+        return jsonify({
+            "alt_text": alt_text,
+            "model": MODEL_NAME,
+            "runtime": "ollama",
+        })
+        
+    except requests.exceptions.ConnectionError:
+        logger.error("Cannot connect to Ollama")
+        return jsonify({
+            "error": "Cannot connect to Ollama. Is it running? Start with: ollama serve"
+        }), 503
+    except Exception as e:
+        logger.error(f"Error generating caption: {e}", exc_info=True)
+        return jsonify({"error": str(e)}), 500
+
+
+if __name__ == "__main__":
+    logger.info(f"Starting Ollama-based alt text server...")
+    logger.info(f"Using model: {MODEL_NAME}")
+    logger.info(f"Ollama host: {OLLAMA_HOST}")
+    
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port, debug=False)
+


### PR DESCRIPTION
- Add ollama_service/ with Flask API using qwen3-vl:4b model
- No PyTorch/Transformers required - just flask + requests
- Model runs via Ollama (3.3GB vs 10GB for Transformers version)
- Produces concise, natural alt text captions
- Update .gitignore for Python environments

## Summary by Sourcery

Introduce a lightweight Ollama-backed alt text generation microservice exposed via a Flask API.

New Features:
- Add a Flask-based HTTP API for generating image alt text using an Ollama-hosted qwen3-vl:4b vision-language model.
- Serve a simple landing page describing the alt text service and its API endpoints.
- Expose health and caption-generation endpoints for checking Ollama status and generating captions from image URLs.

Enhancements:
- Document setup, configuration, and usage of the Ollama-based alt text service in a dedicated README.
- Define a minimal Python requirements file for running the Ollama alt text server without ML framework dependencies.

Build:
- Update gitignore to better support Python development environments.

Documentation:
- Add user-facing documentation for installing Ollama, running the alt text server, and calling its HTTP API.